### PR TITLE
Update travis Cython download to current Ubuntu version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,11 @@ before_install:
   - sudo apt-get -y install check libsasl2-dev libsasl2-2
   - >
       if [ "x`uname -m`" = "xx86_64" ]; then
-        wget http://mirrors.kernel.org/ubuntu/pool/main/c/cython/cython_0.21.1-1_amd64.deb ;
-        sudo dpkg -i cython_0.21.1-1_amd64.deb ;
+        wget http://mirrors.kernel.org/ubuntu/pool/main/c/cython/cython_0.23.4-0ubuntu5_amd64.deb ;
+        sudo dpkg -i cython_0.23.4-0ubuntu5_amd64.deb ;
       else
-        wget http://mirrors.kernel.org/ubuntu/pool/main/c/cython/cython_0.21.1-1_i386.deb ;
-        sudo dpkg -i cython_0.21.1-1_i386.deb ;
+        wget http://mirrors.kernel.org/ubuntu/pool/main/c/cython/cython_0.23.4-0ubuntu5_i386.deb;
+        sudo dpkg -i cython_0.23.4-0ubuntu5_i386.deb ;
       fi
   - wget https://github.com/google/protobuf/releases/download/v2.6.0/protobuf-2.6.0.tar.gz
   - tar -xzf protobuf-2.6.0.tar.gz


### PR DESCRIPTION
The version in the 14.04 repository is still too old -- 0.20.1.