### PR TITLE
Avoid leaking automatically allocated pthread objects in hadoofus 'futures'

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,14 @@ library. It is implemented in C and supports RPC pipelining and out-of-order
 execution. It does not require Java.
 
 It provides a C API for directly calling Namenode RPCs and performing Datanode
-block read and write operations, as well as a `libhdfs`-compatible interface
-in a seperate library (`libhdfs_hadoofus.so`).
+block read and write operations.
 
-It also includes a Python wrapper module, implemented in Cython. (Cython
-compiles to a C Python module.) For more information on that, see
+There is an example `libhdfs`-compatible interface using libhadoofus provided
+in a seperate library (`libhdfs_hadoofus.so`).  It should be considered alpha
+quality, provided as a proof of concept.
+
+Hadoofus also includes a Python 2 wrapper module, implemented in Cython.
+(Cython compiles to a C Python module.) For more information on that, see
 `/wrappers/README.md`.
 
 Unlike libhdfs, Hadoofus speaks multiple versions of the HDFS protocol. At your
@@ -50,8 +53,8 @@ hdfs_namenode_delete(h);
 
 #### Caveats
 
-Some RPCs provided by the Hadoop `ClientProtocol` interface in v2.x of the
-protocol are not yet implemented (see Issue #29).
+Some less common RPCs provided by the Hadoop `ClientProtocol` interface in v2.x
+of the protocol are not yet implemented (see Issue #29).
 
 Note: Hadoop has been known to change semantics slightly between different
 versions of the software (especially before v2 was released). The v1 protocol
@@ -77,19 +80,6 @@ For more information, see [wikipedia's article on Hadoop][0] or the
 
 [0]: https://en.wikipedia.org/wiki/Apache_Hadoop#Hadoop_distributed_file_system "Hadoop distributed file system"
 [1]: https://hadoop.apache.org/docs/r1.2.1/hdfs_design.html
-
-#### ABI Compatibility notes
-
-We aim to preserve ABI compatibility OF THE HIGH-LEVEL C API in future versions
-of this library, with some caveats.
-
-1. Users MUST NOT access struct members directly (even though structs are in
-   public headers).
-2. Users MUST allow for new types of exceptions and do something appropriate
-   with surprising types (i.e., abort, treat it as `IOError`, etc).
-3. Additional HDFS methods may be added. They will follow the naming scheme
-   used throughout this project; users should avoid using such names so that
-   future changes will not cause symbol conflicts.
 
 #### Installing
 

--- a/examples/helloworld.c
+++ b/examples/helloworld.c
@@ -15,7 +15,7 @@ main(int argc, char **argv)
 	struct hdfs_namenode namenode;
 
 	struct hdfs_object *rpc;
-	struct hdfs_rpc_response_future future;
+	struct hdfs_rpc_response_future *future;
 	struct hdfs_object *object;
 
 	if (argc > 1) {
@@ -40,19 +40,21 @@ main(int argc, char **argv)
 		goto out;
 
 	// Call getProtocolVersion(61)
-	future = HDFS_RPC_RESPONSE_FUTURE_INITIALIZER;
+	future = hdfs_rpc_response_future_alloc();
+	hdfs_rpc_response_future_init(future);
 	rpc = hdfs_rpc_invocation_new(
 	    "getProtocolVersion",
 	    hdfs_string_new(HADOOFUS_CLIENT_PROTOCOL_STR),
 	    hdfs_long_new(61),
 	    NULL);
-	err = hdfs_namenode_invoke(&namenode, rpc, &future);
+	err = hdfs_namenode_invoke(&namenode, rpc, future);
 	hdfs_object_free(rpc);
 	if (err)
 		goto out;
 
 	// Get the response (should be long(61))
-	hdfs_future_get(&future, &object);
+	hdfs_future_get(future, &object);
+	hdfs_rpc_response_future_free(&future);
 
 	if (object->ob_type == H_LONG &&
 	    object->ob_val._long._val == 61L)

--- a/src/highlevel.c
+++ b/src/highlevel.c
@@ -67,10 +67,12 @@ hdfs_ ## name (struct hdfs_namenode *h, ##args, struct hdfs_object **exception_o
 
 #define _HDFS_PRIM_RPC_BODY(name, htype, result, retval, dflt, args...) \
 { \
-	struct hdfs_rpc_response_future future = HDFS_RPC_RESPONSE_FUTURE_INITIALIZER; \
+	struct hdfs_rpc_response_future future; \
 	struct hdfs_object *rpc, *object; \
 	const char *error; \
 \
+	future.fu_inited = false; \
+	hdfs_rpc_response_future_init(&future); \
 	rpc = hdfs_rpc_invocation_new( \
 	    #name, \
 	    ##args, \
@@ -112,10 +114,12 @@ hdfs_ ## name (struct hdfs_namenode *h, ##args, struct hdfs_object **exception_o
 
 #define _HDFS_OBJ_RPC_BODY(name, htype, args...) \
 { \
-	struct hdfs_rpc_response_future future = HDFS_RPC_RESPONSE_FUTURE_INITIALIZER; \
+	struct hdfs_rpc_response_future future; \
 	struct hdfs_object *rpc, *object; \
 	const char *error; \
 \
+	future.fu_inited = false; \
+	hdfs_rpc_response_future_init(&future); \
 	rpc = hdfs_rpc_invocation_new( \
 	    #name, \
 	    ##args, \

--- a/src/pthread_wrappers.c
+++ b/src/pthread_wrappers.c
@@ -5,6 +5,38 @@
 #include "util.h"
 
 void
+_mtx_init(pthread_mutex_t *l)
+{
+	int rc;
+	rc = pthread_mutex_init(l, NULL);
+	ASSERT(rc == 0);
+}
+
+void
+_mtx_destroy(pthread_mutex_t *l)
+{
+	int rc;
+	rc = pthread_mutex_destroy(l);
+	ASSERT(rc == 0);
+}
+
+void
+_cond_init(pthread_cond_t *c)
+{
+	int rc;
+	rc = pthread_cond_init(c, NULL);
+	ASSERT(rc == 0);
+}
+
+void
+_cond_destroy(pthread_cond_t *c)
+{
+	int rc;
+	rc = pthread_cond_destroy(c);
+	ASSERT(rc == 0);
+}
+
+void
 _lock(pthread_mutex_t *l)
 {
 	int rc;

--- a/src/pthread_wrappers.h
+++ b/src/pthread_wrappers.h
@@ -4,6 +4,10 @@
 #include <stdint.h>
 #include <pthread.h>
 
+void	_mtx_init(pthread_mutex_t *l);
+void	_mtx_destroy(pthread_mutex_t *l);
+void	_cond_init(pthread_cond_t *c);
+void	_cond_destroy(pthread_cond_t *c);
 void	_lock(pthread_mutex_t *l);
 void	_unlock(pthread_mutex_t *l);
 void	_wait(pthread_mutex_t *l, pthread_cond_t *c);

--- a/src/util.h
+++ b/src/util.h
@@ -6,7 +6,17 @@
 #include <stdint.h>
 #include <time.h>
 
+#include <pthread.h>
+
 #include <protobuf-c/protobuf-c.h>
+
+struct hdfs_rpc_response_future {
+	pthread_mutex_t fu_lock;
+	pthread_cond_t fu_cond;
+	struct hdfs_object *fu_res;
+	struct hdfs_namenode *fu_namenode;
+	bool fu_inited;
+};
 
 #define nelem(arr) (sizeof(arr) / sizeof(arr[0]))
 


### PR DESCRIPTION
Similar leaks (on pointer pthread object platforms) remain, but this fixes some of the most egregious of them.

Again, reported by Alex Smith.  Thanks!