### PR TITLE
Fix more pthread object leaks (like e617c4b)

### DIFF
--- a/src/datanode.c
+++ b/src/datanode.c
@@ -170,7 +170,7 @@ hdfs_datanode_init(struct hdfs_datanode *d,
 	ASSERT(proto == HDFS_DATANODE_AP_1_0 || proto == HDFS_DATANODE_CDH3 ||
 	    proto == HDFS_DATANODE_AP_2_0);
 
-	d->dn_lock = (pthread_mutex_t)PTHREAD_MUTEX_INITIALIZER;
+	_mtx_init(&d->dn_lock);
 	d->dn_sock = -1;
 	d->dn_used = false;
 
@@ -217,6 +217,7 @@ hdfs_datanode_destroy(struct hdfs_datanode *d)
 	free(d->dn_pool_id);
 	_unlock(&d->dn_lock);
 
+	_mtx_destroy(&d->dn_lock);
 	memset(d, 0, sizeof *d);
 }
 

--- a/src/namenode.c
+++ b/src/namenode.c
@@ -47,8 +47,8 @@ hdfs_namenode_allocate(void)
 EXPORT_SYM void
 hdfs_namenode_init(struct hdfs_namenode *n, enum hdfs_kerb kerb_prefs)
 {
-	n->nn_lock = (pthread_mutex_t)PTHREAD_MUTEX_INITIALIZER;
-	n->nn_sendlock = (pthread_mutex_t)PTHREAD_MUTEX_INITIALIZER;
+	_mtx_init(&n->nn_lock);
+	_mtx_init(&n->nn_sendlock);
 	n->nn_refs = 1;
 	n->nn_sock = -1;
 	n->nn_dead = false;
@@ -562,6 +562,8 @@ _namenode_decref(struct hdfs_namenode *n)
 			dcb = n->nn_destroy_cb;
 		if (n->nn_sasl_ctx)
 			sasl_dispose(&n->nn_sasl_ctx);
+		_mtx_destroy(&n->nn_lock);
+		_mtx_destroy(&n->nn_sendlock);
 		memset(n, 0, sizeof *n);
 		if (dcb)
 			dcb(n);


### PR DESCRIPTION
As mentioned in 5396d04, some implementations may allocate memory on first
use of a statically-initialized object.  So use the explicit routines to
release any such allocations when we're done with the pthread lock.

Reported by:	Alex Smith <aes7mv AT virginia.edu>