### PR TITLE
Push assertion format string out to the invocation

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -1,3 +1,4 @@
+#include <stdarg.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -47,13 +48,16 @@ _now_ms(void)
 }
 
 void
-assert_fail(const char *an, const char *fn, const char *file, unsigned line)
+assert_fail(const char *fmt, ...)
 {
 	void *stack[16];
 	size_t nframes;
+	va_list ap;
 
-	fprintf(stderr, "ASSERTION `%s' FAILED in %s (%s:%u)\n", an, fn, file,
-	    line);
+	va_start(ap, fmt);
+	vfprintf(stderr, fmt, ap);
+	va_end(ap);
+
 	fprintf(stderr, "Stack:\n--------------------------------------\n");
 	fflush(stderr);
 

--- a/src/util.h
+++ b/src/util.h
@@ -28,11 +28,12 @@ struct hdfs_rpc_response_future {
 	if ((intptr_t)(cond))					\
 		break;						\
 								\
-	assert_fail(#cond, __func__, __FILE__, __LINE__);	\
+	assert_fail("ASSERTION `%s' FAILED in %s (%s:%u)\n",	\
+	    #cond, __func__, __FILE__, __LINE__);		\
 } while (false)
 
-void	assert_fail(const char *an, const char *fn, const char *file, unsigned line)
-	__attribute__((noreturn));
+void	assert_fail(const char *fmt, ...)
+	__attribute__((noreturn)) __attribute__((format(printf, 1, 2)));
 
 #ifdef NO_EXPORT_SYMS
 # define EXPORT_SYM


### PR DESCRIPTION
No functional change.  Will be useful for adding different assertion
messages.