### PR TITLE
Fix #51 - Abort pending RPC futures with fake "exception"

### DIFF
--- a/include/lowlevel.h
+++ b/include/lowlevel.h
@@ -27,100 +27,6 @@ struct hdfs_rpc_response_future;
 
 typedef void (*hdfs_namenode_destroy_cb)(struct hdfs_namenode *);
 
-enum hdfs_error_kind {
-	he_errno,
-	he_gaierr,
-	he_saslerr,
-	he_hdfserr,
-};
-#define _he_num_kinds (he_hdfserr + 1)
-
-#define _HDFS_ERR_MINIMUM HDFS_ERR_END_OF_STREAM
-enum hdfs_error_numeric {
-	// I.e., remote end closed the TCP connection or middleman injected
-	// RST.
-	HDFS_ERR_END_OF_STREAM = 1,
-	// Input file shorter than expected, or unexpected zero write(2)ing
-	// output.
-	HDFS_ERR_END_OF_FILE,
-
-	// Programmer misuse of API
-	HDFS_ERR_NAMENODE_UNCONNECTED,
-	HDFS_ERR_NAMENODE_UNAUTHENTICATED,
-
-	// Error returned on reads if the user requested CRC validation but the
-	// server did not transmit CRCs.
-	HDFS_ERR_DATANODE_NO_CRCS,
-	// Need at least one datanode to connect, obviously.
-	HDFS_ERR_ZERO_DATANODES,
-
-// Direct translations of Datanode STATUS codes.  More information may be
-// available in the hdfs_datanode_opresult_message (optionally provided by HDFS
-// datanode).  If no message was provided, the pointer will be NULL.
-	HDFS_ERR_DN_ERROR,
-	HDFS_ERR_DN_ERROR_CHECKSUM,
-	HDFS_ERR_DN_ERROR_INVALID,
-	HDFS_ERR_DN_ERROR_EXISTS,
-	HDFS_ERR_DN_ERROR_ACCESS_TOKEN,
-	// Or STATUS code not recognized by libhadoofus; check
-	// hdfs_datanode_unknown_status to determine value.
-	HDFS_ERR_UNRECOGNIZED_DN_ERROR,
-	// STATUS code was recognized, but not valid in the scenario.  The
-	// value can be checked with hdfs_datanode_unknown_status.
-	HDFS_ERR_INVALID_DN_ERROR,
-
-// Protocol encoding errors
-	// HDFS wire messages are prefixed with a length.  That length is
-	// itself variable in length.  This error means the encoding of that
-	// length prefix was erroneous.
-	HDFS_ERR_INVALID_VLINT,
-	// Protobuf decode failures:
-	HDFS_ERR_INVALID_BLOCKOPRESPONSEPROTO,
-	HDFS_ERR_INVALID_PACKETHEADERPROTO,
-	HDFS_ERR_INVALID_PIPELINEACKPROTO,
-	// v1 DN wire protocol errors
-	HDFS_ERR_V1_DATANODE_PROTOCOL,
-
-// Other protocol errors
-	// A SUCCESS OpRes had a message attached; as usual, the message can be
-	// found in hdfs_datanode_opresult_message.
-	HDFS_ERR_INVALID_DN_OPRESP_MSG,
-	HDFS_ERR_DATANODE_PACKET_SIZE,
-	// The packet's expressed CRCs length doesn't match the data length
-	HDFS_ERR_DATANODE_CRC_LEN,
-	// We got a non-zero CRCs length when we didn't expect CRCs
-	HDFS_ERR_DATANODE_UNEXPECTED_CRC_LEN,
-	HDFS_ERR_DATANODE_UNEXPECTED_READ_OFFSET,
-	HDFS_ERR_DATANODE_BAD_CHECKSUM,
-	HDFS_ERR_DATANODE_BAD_SEQNO,
-	// Packet ACK count did not match the number of datanodes in the
-	// pipeline
-	HDFS_ERR_DATANODE_BAD_ACK_COUNT,
-	// Last packet flag set when we expected more packets
-	HDFS_ERR_DATANODE_BAD_LASTPACKET,
-	// Kerberos downgrade attempt when client requested enforcing mode;
-	// possible MITM attack.
-	HDFS_ERR_KERBEROS_DOWNGRADE,
-	// Unexpected and unhandled error negotiating kerberos
-	HDFS_ERR_KERBEROS_NEGOTIATION,
-	_HDFS_ERR_END
-};
-#define _HDFS_ERR_MAXIMUM (_HDFS_ERR_END - 1)
-
-#define _HE_KIND_BITS 2
-#define _HE_NUM_BITS (32 - _HE_KIND_BITS)
-struct hdfs_error {
-	enum hdfs_error_kind her_kind : _HE_KIND_BITS;
-	int her_num : _HE_NUM_BITS;
-};
-_Static_assert((1 << _HE_KIND_BITS) >= _he_num_kinds,
-    "if we grow more kinds of error, we need to expand the width of her_kind");
-_Static_assert(sizeof(struct hdfs_error) == sizeof(uint32_t),
-    "for now, attempt to return a 32-bit value for 32-bit platforms where a "
-    "64-bit return is slightly more expenisve");
-
-#define HDFS_SUCCESS	(struct hdfs_error) {}
-
 struct hdfs_namenode {
 	pthread_mutex_t nn_lock;
 	int64_t nn_msgno;
@@ -169,19 +75,6 @@ struct hdfs_datanode {
 
 extern _Thread_local int hdfs_datanode_unknown_status;
 extern _Thread_local const char *hdfs_datanode_opresult_message;
-
-// Return true if the struct represents an unsucessful result.
-static inline bool
-hdfs_is_error(struct hdfs_error herr)
-{
-	return (herr.her_kind != 0 || herr.her_num != 0);
-}
-
-// Return a string representation of hdfs_error::her_kind.
-const char *hdfs_error_str_kind(struct hdfs_error);
-
-// Return a string representation of hdfs_error::her_num.
-const char *hdfs_error_str(struct hdfs_error);
 
 //
 // Namenode operations
@@ -242,14 +135,40 @@ void		hdfs_rpc_response_future_clean(struct hdfs_rpc_response_future *);
 // Either way, clean() and free() to release allocated resources.
 void		hdfs_rpc_response_future_free(struct hdfs_rpc_response_future **);
 
-// hdfs_future_get invokes hdfs_rpc_response_future_clean, and the caller does
-// not need to.
+// hdfs_future_get waits until the promised object is available and emits it in
+// the outparameter.  It will either be the appropriate response type, NULL (of
+// the appropriate type), or an H_PROTOCOL_EXCEPTION.
+//
+// H_PROTOCOL_EXCEPTION objects have an _etype member that can be used to
+// determine the kind of exception raised.
+//
+// If the future was aborted due to a socket error, protocol parse error, or
+// user induced shutdown of the namenode connection, a specific exception of
+// _etype H_HADOOFUS_RPC_ABORTED is raised.  If that is the etype, the
+// hdfs_error value can be retrieved with hdfs_pseudo_exception_get_error().
+//
+// Possible errors include:
+//
+//   * Caller told us to shutdown (destroy):
+//     he_hdfserr: HDFS_ERR_NAMENODE_UNCONNECTED
+//
+//   * Server or middlebox closed the socket (TCP RST):
+//     he_hdfserr: HDFS_ERR_END_OF_STREAM
+//
+//   * Other socket errors:
+//     he_errno: Anything recv(2) may return, aside from EAGAIN/EWOULDBLOCK
+//
+//   * We were unable to parse the response from the Namenode:
+//     he_hdfserr: HDFS_ERR_NAMENODE_PROTOCOL
+//
+// (hdfs_future_get invokes hdfs_rpc_response_future_clean, and the caller does
+// not need to in order to reuse the future.)
 void		hdfs_future_get(struct hdfs_rpc_response_future *, struct hdfs_object **);
 
+// Like regular hdfs_future_get, but with bounded wait.
+//
 // Returns 'false' if the RPC received no response in the time limit. The
-// Namenode object still references the future.
-// If 'true' is returned, same result as hdfs_future_get (including
-// hdfs_rpc_response_future_clean).
+// Namenode object still owns the future.
 bool		hdfs_future_get_timeout(struct hdfs_rpc_response_future *, struct hdfs_object **, uint64_t limitms);
 
 // Destroys the connection. Note that the memory may still be in use by a child

--- a/include/objects.h
+++ b/include/objects.h
@@ -9,6 +9,116 @@
 #define HADOOFUS_CLIENT_PROTOCOL_STR "org.apache.hadoop.hdfs.protocol.ClientProtocol"
 #define _HDFS_CLIENT_ID_LEN 16
 
+enum hdfs_error_kind {
+	he_errno,
+	he_gaierr,
+	he_saslerr,
+	he_hdfserr,
+};
+#define _he_num_kinds (he_hdfserr + 1)
+
+#define _HDFS_ERR_MINIMUM HDFS_ERR_END_OF_STREAM
+enum hdfs_error_numeric {
+	// I.e., remote end closed the TCP connection or middleman injected
+	// RST.
+	HDFS_ERR_END_OF_STREAM = 1,
+	// Input file shorter than expected, or unexpected zero write(2)ing
+	// output.
+	HDFS_ERR_END_OF_FILE,
+
+	// Programmer misuse of API
+	HDFS_ERR_NAMENODE_UNCONNECTED,
+	HDFS_ERR_NAMENODE_UNAUTHENTICATED,
+
+	// Error returned on reads if the user requested CRC validation but the
+	// server did not transmit CRCs.
+	HDFS_ERR_DATANODE_NO_CRCS,
+	// Need at least one datanode to connect, obviously.
+	HDFS_ERR_ZERO_DATANODES,
+
+// Direct translations of Datanode STATUS codes.  More information may be
+// available in the hdfs_datanode_opresult_message (optionally provided by HDFS
+// datanode).  If no message was provided, the pointer will be NULL.
+	HDFS_ERR_DN_ERROR,
+	HDFS_ERR_DN_ERROR_CHECKSUM,
+	HDFS_ERR_DN_ERROR_INVALID,
+	HDFS_ERR_DN_ERROR_EXISTS,
+	HDFS_ERR_DN_ERROR_ACCESS_TOKEN,
+	// Or STATUS code not recognized by libhadoofus; check
+	// hdfs_datanode_unknown_status to determine value.
+	HDFS_ERR_UNRECOGNIZED_DN_ERROR,
+	// STATUS code was recognized, but not valid in the scenario.  The
+	// value can be checked with hdfs_datanode_unknown_status.
+	HDFS_ERR_INVALID_DN_ERROR,
+
+// Protocol encoding errors
+	// HDFS wire messages are prefixed with a length.  That length is
+	// itself variable in length.  This error means the encoding of that
+	// length prefix was erroneous.
+	HDFS_ERR_INVALID_VLINT,
+	// Protobuf decode failures:
+	HDFS_ERR_INVALID_BLOCKOPRESPONSEPROTO,
+	HDFS_ERR_INVALID_PACKETHEADERPROTO,
+	HDFS_ERR_INVALID_PIPELINEACKPROTO,
+	// v1 DN wire protocol errors
+	HDFS_ERR_V1_DATANODE_PROTOCOL,
+
+	// Other namenode protocol response parsing failures
+	HDFS_ERR_NAMENODE_PROTOCOL,
+
+// Other protocol errors
+	// A SUCCESS OpRes had a message attached; as usual, the message can be
+	// found in hdfs_datanode_opresult_message.
+	HDFS_ERR_INVALID_DN_OPRESP_MSG,
+	HDFS_ERR_DATANODE_PACKET_SIZE,
+	// The packet's expressed CRCs length doesn't match the data length
+	HDFS_ERR_DATANODE_CRC_LEN,
+	// We got a non-zero CRCs length when we didn't expect CRCs
+	HDFS_ERR_DATANODE_UNEXPECTED_CRC_LEN,
+	HDFS_ERR_DATANODE_UNEXPECTED_READ_OFFSET,
+	HDFS_ERR_DATANODE_BAD_CHECKSUM,
+	HDFS_ERR_DATANODE_BAD_SEQNO,
+	// Packet ACK count did not match the number of datanodes in the
+	// pipeline
+	HDFS_ERR_DATANODE_BAD_ACK_COUNT,
+	// Last packet flag set when we expected more packets
+	HDFS_ERR_DATANODE_BAD_LASTPACKET,
+	// Kerberos downgrade attempt when client requested enforcing mode;
+	// possible MITM attack.
+	HDFS_ERR_KERBEROS_DOWNGRADE,
+	// Unexpected and unhandled error negotiating kerberos
+	HDFS_ERR_KERBEROS_NEGOTIATION,
+	_HDFS_ERR_END
+};
+#define _HDFS_ERR_MAXIMUM (_HDFS_ERR_END - 1)
+
+#define _HE_KIND_BITS 2
+#define _HE_NUM_BITS (32 - _HE_KIND_BITS)
+struct hdfs_error {
+	enum hdfs_error_kind her_kind : _HE_KIND_BITS;
+	int her_num : _HE_NUM_BITS;
+};
+_Static_assert((1 << _HE_KIND_BITS) >= _he_num_kinds,
+    "if we grow more kinds of error, we need to expand the width of her_kind");
+_Static_assert(sizeof(struct hdfs_error) == sizeof(uint32_t),
+    "for now, attempt to return a 32-bit value for 32-bit platforms where a "
+    "64-bit return is slightly more expenisve");
+
+#define HDFS_SUCCESS	(struct hdfs_error) {}
+
+// Return true if the struct represents an unsucessful result.
+static inline bool
+hdfs_is_error(struct hdfs_error herr)
+{
+	return (herr.her_kind != 0 || herr.her_num != 0);
+}
+
+// Return a string representation of hdfs_error::her_kind.
+const char *hdfs_error_str_kind(struct hdfs_error);
+
+// Return a string representation of hdfs_error::her_num.
+const char *hdfs_error_str(struct hdfs_error);
+
 enum hdfs_kerb {
 	HDFS_NO_KERB,      // plaintext username (default)
 	HDFS_TRY_KERB,     // attempt kerb, but allow fallback to plaintext
@@ -102,6 +212,9 @@ enum hdfs_object_type {
 	H_SASL_EXCEPTION,
 	H_RPC_EXCEPTION,
 	H_RPC_NO_SUCH_METHOD_EXCEPTION,
+	/* Namenode recv_worker encountered an error, or was destroyed. */
+	H_HADOOFUS_RPC_ABORTED,
+
 	_H_END,
 	_H_INVALID = _H_END,
 };
@@ -303,7 +416,10 @@ struct hdfs_fsserverdefaults {
 };
 
 struct hdfs_exception {
-	char *_msg;
+	union {
+		char *_msg;
+		struct hdfs_error _error;
+	};
 	enum hdfs_object_type _etype;
 };
 
@@ -379,6 +495,8 @@ struct hdfs_object *	hdfs_authheader_new_ext(enum hdfs_namenode_proto,
 			const char * /*user*/, const char * /*real user*/,
 			enum hdfs_kerb);
 struct hdfs_object *	hdfs_protocol_exception_new(enum hdfs_object_type, const char *);
+struct hdfs_object *	hdfs_pseudo_exception_new(struct hdfs_error);
+struct hdfs_error	hdfs_pseudo_exception_get_error(const struct hdfs_object *);
 struct hdfs_object *	hdfs_token_new(const char *, const char *, const char *, const char *);
 struct hdfs_object *	hdfs_token_new_empty(void);
 struct hdfs_object *	hdfs_token_new_nulsafe(const char *id, size_t idlen,

--- a/src/objects.c
+++ b/src/objects.c
@@ -127,6 +127,8 @@ static struct {
 		.type = RPC_EXCEPTION_STR, },
 	[H_RPC_NO_SUCH_METHOD_EXCEPTION - H_PROTOCOL_EXCEPTION] = {
 		.type = RPC_ENOENT_EXCEPTION_STR, },
+	[H_HADOOFUS_RPC_ABORTED - H_PROTOCOL_EXCEPTION] = {
+		.type = "not.a.real.Exception", },
 };
 
 enum hdfs_object_type
@@ -1072,6 +1074,28 @@ hdfs_protocol_exception_new(enum hdfs_object_type etype, const char *msg)
 }
 
 EXPORT_SYM struct hdfs_object *
+hdfs_pseudo_exception_new(struct hdfs_error error)
+{
+	struct hdfs_object *r = _objmalloc();
+
+	r->ob_type = H_PROTOCOL_EXCEPTION;
+	r->ob_val._exception = (struct hdfs_exception) {
+		._etype = H_HADOOFUS_RPC_ABORTED,
+		._error = error,
+	};
+	return r;
+}
+
+EXPORT_SYM struct hdfs_error
+hdfs_pseudo_exception_get_error(const struct hdfs_object *obj)
+{
+	ASSERT(obj->ob_type == H_PROTOCOL_EXCEPTION);
+	ASSERT(obj->ob_val._exception._etype == H_HADOOFUS_RPC_ABORTED);
+
+	return obj->ob_val._exception._error;
+}
+
+EXPORT_SYM struct hdfs_object *
 hdfs_array_string_new(int32_t len, const char **strings)
 {
 	struct hdfs_object *r = _objmalloc();
@@ -1433,7 +1457,8 @@ hdfs_object_free(struct hdfs_object *obj)
 			free(obj->ob_val._token._strings[i]);
 		break;
 	case H_PROTOCOL_EXCEPTION:
-		free(obj->ob_val._exception._msg);
+		if (obj->ob_val._exception._etype != H_HADOOFUS_RPC_ABORTED)
+			free(obj->ob_val._exception._msg);
 		break;
 	case H_UPGRADE_ACTION:
 		/* FALLTHROUGH */

--- a/src/util.c
+++ b/src/util.c
@@ -111,7 +111,8 @@ static const char *hdfs_strerror_table[] = {
 	[HDFS_ERR_INVALID_BLOCKOPRESPONSEPROTO] = "bad protocol: could not decode BlockOpResponseProto",
 	[HDFS_ERR_INVALID_PACKETHEADERPROTO] = "bad protocol: could not decode PacketHeaderProto",
 	[HDFS_ERR_INVALID_PIPELINEACKPROTO] = "bad protocol: could not decode PipelineAckProto",
-	[HDFS_ERR_V1_DATANODE_PROTOCOL] = "Invalid protocol data",
+	[HDFS_ERR_V1_DATANODE_PROTOCOL] = "invalid Datanode protocol data",
+	[HDFS_ERR_NAMENODE_PROTOCOL] = "could not parse response from Namenode",
 
 	[HDFS_ERR_INVALID_DN_OPRESP_MSG] = "successful datanode operation had non-empty error message",
 	[HDFS_ERR_DATANODE_PACKET_SIZE] = "got bogus packet size",


### PR DESCRIPTION
When the namenode recv_worker thread exits for any reason with outstanding
RPCs pending, raise a specific pseudo-exception object that contains an
error reason.  The exception type is H_HADOOFUS_RPC_ABORTED.

The hdfs_error value is accessed from the hdfs_object with
hdfs_pseudo_exception_get_error().  Possible errors include:

  * Caller told us to shutdown (destroy):
    he_hdfserr: HDFS_ERR_NAMENODE_UNCONNECTED

  * Server or middlebox closed the socket (TCP RST):
    he_hdfserr: HDFS_ERR_END_OF_STREAM

  * Other socket errors:
    he_errno: Anything recv(2) may return, aside from EAGAIN/EWOULDBLOCK

  * We were unable to parse the response from the Namenode:
    he_hdfserr: HDFS_ERR_NAMENODE_PROTOCOL

Reported by:	Alex Smith <aes7mv AT virginia.edu>