### PR TITLE
Fix #55 - coerce create() return type to FileStatus pointer

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Found a bug? Please file it on github. Thanks!
 * Tom Arnfeld &lt;tarnfeld@me.com&gt;
 * Conrad Meyer &lt;conrad.meyer@isilon.com&gt;
 * Paul Scott &lt;paul@duedil.com&gt;
+* Alex Smith &lt;aes7mv AT virginia.edu&gt;
 
 #### License
 

--- a/include/highlevel.h
+++ b/include/highlevel.h
@@ -79,13 +79,15 @@ hdfs_exception_get_message(struct hdfs_object *o)
 //
 // TODO: borrow individual routine documentation from pyhdfs
 //
-// These routines set exception_out on exception; callers should check this
-// first. When an RPC sets exception_out, the return value is undefined.
+// These routines set *exception_out on exception; callers should check this
+// first. When an RPC sets *exception_out, the return value is undefined.
 // (Callers are responsible for freeing the exception object.)
 //
 // When these routines return an hdfs_object, the caller is responsible for
-// freeing it. The hdfs_object will be an H_NULL value or the expected type for
-// the given RPC.
+// freeing it. The hdfs_object will be the expected type for the given RPC.
+//
+// Some routine may return NULL and set *exception_out to NULL. This indicates
+// a successful RPC invocation, with NULL or no result.
 //
 
 int64_t			hdfs_getProtocolVersion(struct hdfs_namenode *,
@@ -95,7 +97,8 @@ int64_t			hdfs_getProtocolVersion(struct hdfs_namenode *,
 struct hdfs_object *	hdfs_getBlockLocations(struct hdfs_namenode *, const char *path,
 			int64_t offset, int64_t length, struct hdfs_object **exception_out);
 
-void			hdfs_create(struct hdfs_namenode *, const char *path,
+// 'void' prior to v2.2, and result will always be NULL for those versions.
+struct hdfs_object *	hdfs_create(struct hdfs_namenode *, const char *path,
 			uint16_t perms, const char *clientname, bool overwrite,
 			bool create_parent, int16_t replication, int64_t blocksize,
 			struct hdfs_object **exception_out);

--- a/include/objects.h
+++ b/include/objects.h
@@ -223,11 +223,6 @@ const char *	hdfs_etype_to_string(enum hdfs_object_type e);
 
 struct hdfs_object;
 
-/*
- * Users should not use these structs directly, or even access them directly
- * out of an hdfs_object! Instead, only helper functions and generic
- * hdfs_objects should be used.
- */
 struct hdfs_void {
 };
 

--- a/src/rpc2.c
+++ b/src/rpc2.c
@@ -447,10 +447,6 @@ _oslurp_ ## lowerCamel (struct hdfs_heap_buf *buf)			\
 	_DECODE_PB_NULLABLE(lowerCamel, CamelCase, lower_case, objbuilder, respfield,	\
 	    hdfs_null_new(htype))
 
-#define DECODE_PB_VOIDABLE(lowerCamel, CamelCase, lower_case, objbuilder, respfield)	\
-	_DECODE_PB_NULLABLE(lowerCamel, CamelCase, lower_case, objbuilder, respfield,	\
-	    hdfs_void_new())
-
 #define DECODE_PB_VOID(lowerCamel, CamelCase, lower_case)		\
 	DECODE_PB_EX(lowerCamel, CamelCase, lower_case,			\
 	    result = hdfs_void_new())
@@ -459,8 +455,14 @@ _oslurp_ ## lowerCamel (struct hdfs_heap_buf *buf)			\
 DECODE_PB(getServerDefaults, GetServerDefaults, get_server_defaults, fsserverdefaults, serverdefaults)
 DECODE_PB_NULLABLE(getListing, GetListing, get_listing, directory_listing, dirlist, H_DIRECTORY_LISTING)
 DECODE_PB_NULLABLE(getBlockLocations, GetBlockLocations, get_block_locations, located_blocks, locations, H_LOCATED_BLOCKS)
-/* HDFSv2.2+ returns a FileStatus, while 2.0.x and 1.x return void. */
-DECODE_PB_VOIDABLE(create, Create, create, file_status, fs)
+/*
+ * HDFSv2.2+ returns a FileStatus, while 2.0.x and 1.x return void.
+ *
+ * This is represented in the shared protobuf as a NULL 'fs'.  Also, the same
+ * high-level wrapper is used across all versions, so we represent void in
+ * earlier versions as a return value of (FileStatus *)NULL.
+ */
+DECODE_PB_NULLABLE(create, Create, create, file_status, fs, H_FILE_STATUS)
 DECODE_PB(delete, Delete, delete, boolean, result)
 DECODE_PB_NULLABLE(append, Append, append, located_block, block,
     H_LOCATED_BLOCK);


### PR DESCRIPTION
Expand the highlevel RPC create() wrapper to return FileStatus*.  On v1 and
v2.0, this will always be NULL (as a proxy for void).  On v2.2, returns a
real FileStatus value as expected.