### PR TITLE
Fix #56 - explicitly signal recv_worker thread from namenode_destroy() operation

### DIFF
--- a/examples/helloworld.c
+++ b/examples/helloworld.c
@@ -71,7 +71,7 @@ out:
 		    hdfs_error_str_kind(err), hdfs_error_str(err));
 
 	// Destroy any resources used by the connection
-	hdfs_namenode_destroy(&namenode, NULL);
+	hdfs_namenode_destroy(&namenode);
 
 	return hdfs_is_error(err);
 }

--- a/examples/mt-hello.c
+++ b/examples/mt-hello.c
@@ -124,7 +124,7 @@ out:
 		    hdfs_error_str_kind(error), hdfs_error_str(error));
 
 	// Destroy any resources used by the connection
-	hdfs_namenode_destroy(&namenode, NULL);
+	hdfs_namenode_destroy(&namenode);
 
 	return hdfs_is_error(error);
 }

--- a/src/highlevel.c
+++ b/src/highlevel.c
@@ -47,7 +47,8 @@ out:
 EXPORT_SYM void
 hdfs_namenode_delete(struct hdfs_namenode *h)
 {
-	hdfs_namenode_destroy(h, (hdfs_namenode_destroy_cb)free);
+	hdfs_namenode_destroy(h);
+	free(h);
 }
 
 // RPC implementations

--- a/src/util.h
+++ b/src/util.h
@@ -14,8 +14,8 @@ struct hdfs_rpc_response_future {
 	pthread_mutex_t fu_lock;
 	pthread_cond_t fu_cond;
 	struct hdfs_object *fu_res;
-	struct hdfs_namenode *fu_namenode;
-	bool fu_inited;
+	bool fu_inited : 1;
+	bool fu_invoked : 1;
 };
 
 #define nelem(arr) (sizeof(arr) / sizeof(arr[0]))

--- a/wrappers/py/clowlevel.pxd
+++ b/wrappers/py/clowlevel.pxd
@@ -5,7 +5,6 @@ from posix.unistd cimport off_t
 from cobjects cimport hdfs_object
 
 cdef extern from "hadoofus/lowlevel.h":
-    ctypedef void (*hdfs_namenode_destroy_cb)(hdfs_namenode*)
     cdef struct hdfs_namenode:
         pass
     cdef struct _hdfs_pending:
@@ -51,7 +50,7 @@ cdef extern from "hadoofus/lowlevel.h":
     int64_t hdfs_namenode_get_msgno(hdfs_namenode *n) nogil
     hdfs_error hdfs_namenode_invoke(hdfs_namenode *n, hdfs_object *o, hdfs_rpc_response_future *f) nogil
     void hdfs_future_get(hdfs_rpc_response_future *f, hdfs_object **o_out) nogil
-    void hdfs_namenode_destroy(hdfs_namenode *n, hdfs_namenode_destroy_cb cb) nogil
+    void hdfs_namenode_destroy(hdfs_namenode *n) nogil
     void hdfs_datanode_init(hdfs_datanode *d, int64_t blkid, int64_t size, int64_t gen, int64_t offset, const_char *client, hdfs_object *token, int proto) nogil
     hdfs_error hdfs_datanode_connect(hdfs_datanode *d, const_char *host, const_char *port) nogil
     hdfs_error hdfs_datanode_write(hdfs_datanode *d, void *buf, size_t len, bint sendcrcs) nogil

--- a/wrappers/py/hadoofus.pyx
+++ b/wrappers/py/hadoofus.pyx
@@ -18,7 +18,7 @@ from chighlevel cimport hdfs_getProtocolVersion, hdfs_getBlockLocations, hdfs_cr
         hdfs2_getServerDefaults, hdfs2_getFileLinkInfo, hdfs2_createSymlink, \
         hdfs2_getLinkTarget
 from clowlevel cimport hdfs_namenode, hdfs_namenode_init, hdfs_namenode_destroy, \
-        hdfs_namenode_destroy_cb, hdfs_namenode_connect, hdfs_namenode_authenticate, \
+        hdfs_namenode_connect, hdfs_namenode_authenticate, \
         hdfs_datanode, hdfs_datanode_read_file, hdfs_datanode_read, hdfs_datanode_write, \
         hdfs_datanode_write_file, hdfs_datanode_connect, hdfs_namenode_get_msgno, \
         hdfs_namenode_set_version, hdfs_namenode_authenticate_full, hdfs_error, \
@@ -1189,7 +1189,7 @@ cdef class rpc:
 
     def __dealloc__(self):
         with nogil:
-            hdfs_namenode_destroy(&self.nn, NULL)
+            hdfs_namenode_destroy(&self.nn)
 
     def __init__(self, addr, protocol=HADOOP_1_0, user=None, port=None, kerb=NO_KERB, **kwargs):
         """


### PR DESCRIPTION
Be sure to wake recv_worker thread in destroy(), in case it is stuck in
poll() while an operation is pending (blocking last ref cleanup).