### PR TITLE
Fix #59 - Use IPs instead of hostnames for datanode connections

### DIFF
--- a/include/objects.h
+++ b/include/objects.h
@@ -284,7 +284,8 @@ struct hdfs_directory_listing {
 
 struct hdfs_datanode_info {
 	char *_location/* rack */;
-	char *_hostname,
+	char *_ipaddr,
+	     *_hostname,
 	     *_port;
 	uint16_t _namenodeport;
 	/* "name" is hostname:port, "hostname" is just hostname */
@@ -461,7 +462,7 @@ struct hdfs_object *	hdfs_located_block_copy(struct hdfs_object *);
 struct hdfs_object *	hdfs_located_blocks_new(bool beingcreated, int64_t size);
 struct hdfs_object *	hdfs_directory_listing_new(void);
 struct hdfs_object *	hdfs_located_directory_listing_new(void);
-struct hdfs_object *	hdfs_datanode_info_new(const char *host, const char *port,
+struct hdfs_object *	hdfs_datanode_info_new(const char *ipaddr, const char *host, const char *port,
 			const char *rack, uint16_t namenodeport);
 struct hdfs_object *	hdfs_datanode_info_copy(struct hdfs_object *);
 struct hdfs_object *	hdfs_array_datanode_info_new(void);

--- a/src/datanode.c
+++ b/src/datanode.c
@@ -132,7 +132,7 @@ hdfs_datanode_new(struct hdfs_object *located_block, const char *client,
 		    located_block->ob_val._located_block._locs[i];
 
 		error = hdfs_datanode_connect(d,
-		    di->ob_val._datanode_info._hostname,
+		    di->ob_val._datanode_info._ipaddr,
 		    di->ob_val._datanode_info._port);
 		if (!hdfs_is_error(error))
 			return d;

--- a/src/heapbufobjs.c
+++ b/src/heapbufobjs.c
@@ -330,7 +330,9 @@ _oslurp_datanode_info(struct hdfs_heap_buf *b)
 		goto out;
 	}
 	port++;
-	res = hdfs_datanode_info_new(hostname, port, location, rpcport);
+	// For simplicity, use hostname for ipaddr (in the v1 implementation hadoofus
+	// was originally tested with, the hostname was an ipaddr anyways)
+	res = hdfs_datanode_info_new(hostname/*ipaddr*/, hostname, port, location, rpcport);
 
 out:
 	if (name)

--- a/wrappers/py/cobjects.pxd
+++ b/wrappers/py/cobjects.pxd
@@ -118,6 +118,7 @@ cdef extern from "hadoofus/objects.h":
 
     cdef struct hdfs_datanode_info:
         char* _location
+        char* _ipaddr
         char* _hostname
         char* _port
         uint16_t _namenodeport
@@ -220,7 +221,7 @@ cdef extern from "hadoofus/objects.h":
     hdfs_object *hdfs_located_blocks_new(bint beingcreated, int64_t size)
     hdfs_object *hdfs_directory_listing_new()
     hdfs_object *hdfs_located_directory_listing_new()
-    hdfs_object *hdfs_datanode_info_new(const_char *host, const_char *port, const_char *rack, uint16_t namenodeport)
+    hdfs_object *hdfs_datanode_info_new(const_char *ipaddr, const_char *host, const_char *port, const_char *rack, uint16_t namenodeport)
     hdfs_object *hdfs_datanode_info_copy(hdfs_object *) nogil
     hdfs_object *hdfs_array_datanode_info_new()
     hdfs_object *hdfs_array_datanode_info_copy(hdfs_object *) nogil

--- a/wrappers/py/hadoofus.pyx
+++ b/wrappers/py/hadoofus.pyx
@@ -525,12 +525,13 @@ cdef class block:
 cdef class datanode_info:
     cdef hdfs_object* c_di
 
-    def __init__(self, hostname, port, location, ipc_port):
+    def __init__(self, ipaddr, hostname, port, location, ipc_port):
+        ipaddr_s = str(ipaddr)
         host_s = str(hostname)
         port_s = str(port)
         loc_s = str(location)
-        self.c_di = hdfs_datanode_info_new(host_s, port_s, loc_s,
-                int(ipc_port))
+        self.c_di = hdfs_datanode_info_new(ipaddr_s, host_s, port_s,
+                loc_s, int(ipc_port))
 
     def __cinit__(self):
         self.c_di = NULL
@@ -557,6 +558,15 @@ cdef class datanode_info:
             cdef char* cp = pydup(location)
             free(self.c_di._datanode_info._location)
             self.c_di._datanode_info._location = cp
+
+    property ipaddr:
+        def __get__(self):
+            return self.c_di._datanode_info._ipaddr
+
+        def __set__(self, ipaddr):
+            cdef char* cp = pydup(ipaddr)
+            free(self.c_di._datanode_info._ipaddr)
+            self.c_di._datanode_info._ipaddr = cp
 
     property hostname:
         def __get__(self):


### PR DESCRIPTION
- Also fixed a memory leak where H_DATANODE_INFO hostname and port strings would not be freed
- Unsure about the correctness/completeness of the updates to the Cython wrappers
