### PR TITLE
Fix #46 - Add ExtendedBlockProto and fileid args to complete()/addBlock() RPCs

### DIFF
--- a/include/highlevel.h
+++ b/include/highlevel.h
@@ -118,12 +118,40 @@ void			hdfs_setOwner(struct hdfs_namenode *, const char *path,
 void			hdfs_abandonBlock(struct hdfs_namenode *, struct hdfs_object *block,
 			const char *path, const char *client, struct hdfs_object **exception_out);
 
+/*
+ * 'previous_block' is an H_BLOCK hdfs_block object. One can be obtained from a
+ * H_LOCATED_BLOCK with hdfs_block_from_located_block(). It should be NULL if and
+ * only if there is no previous block (i.e. this is adding the first block to the
+ * file). If previous_block is not NULL, then its _length member must must be set
+ * to the block's correct current size (after any datanode writes that may have
+ * been performed).
+ *
+ * In v1 the arguments 'previous_block' and 'fileid' are ignored (i.e. just pass
+ * NULL and 0 for them, respectively)
+ *
+ * FileId is new in 2.2; pass zero for 2.0 and earlier versions.
+ */
 struct hdfs_object *	hdfs_addBlock(struct hdfs_namenode *, const char *path,
 			const char *client, struct hdfs_object *excluded,
+			struct hdfs_object *previous_block, int64_t fileid,
 			struct hdfs_object **exception_out);
 
+/*
+ * 'last_block' is an H_BLOCK hdfs_block object. One can be obtained from a
+ * H_LOCATED_BLOCK with hdfs_block_from_located_block(). It should be NULL if and
+ * only if there is no last block (i.e. this is completing an empty file that has
+ * had no blocks added to it). If is not NULL, then its _length member must must
+ * be set to the block's correct current size (after any datanode writes that may
+ * have been performed).
+ *
+ * In v1 the arguments 'last_block' and 'fileid' are ignored (i.e. just pass NULL
+ * and 0 for them, respectively)
+ *
+ * FileId is new in 2.2; pass zero for 2.0 and earlier versions.
+ */
 bool			hdfs_complete(struct hdfs_namenode *, const char *path,
-			const char *client, struct hdfs_object **exception_out);
+			const char *client, struct hdfs_object *last_block,
+			int64_t fileid, struct hdfs_object **exception_out);
 
 bool			hdfs_rename(struct hdfs_namenode *, const char *src,
 			const char *dst, struct hdfs_object **exception_out);

--- a/src/objects.c
+++ b/src/objects.c
@@ -1271,8 +1271,7 @@ hdfs_array_string_copy(struct hdfs_object *src)
 	for (i = 0; i < len; i++) {
 		r->ob_val._array_string._val[i] =
 		    strdup(src->ob_val._array_string._val[i]);
-		ASSERT(r->ob_val._array_string._val[i] != NULL ||
-		    src->ob_val._array_string._val[i] == NULL);
+		ASSERT(r->ob_val._array_string._val[i] != NULL);
 	}
 	return r;
 }

--- a/tests/t_datanode_basics.c
+++ b/tests/t_datanode_basics.c
@@ -173,7 +173,8 @@ START_TEST(test_dn_write_buf)
 	begin = _now();
 
 	// write first block (full)
-	bl = hdfs_addBlock(h, tf, client, NULL, &e);
+	// XXX this must be updated to cover v2.0+ (last_block/fileid)
+	bl = hdfs_addBlock(h, tf, client, NULL, NULL, 0, &e);
 	if (e)
 		fail("exception: %s", hdfs_exception_get_message(e));
 
@@ -191,7 +192,8 @@ START_TEST(test_dn_write_buf)
 	hdfs_datanode_delete(dn);
 
 	// write second block (partial)
-	bl = hdfs_addBlock(h, tf, client, NULL, &e);
+	// XXX this must be updated to cover v2.0+ (last_block/fileid)
+	bl = hdfs_addBlock(h, tf, client, NULL, NULL, 0, &e);
 	if (e)
 		fail("exception: %s", hdfs_exception_get_message(e));
 
@@ -216,7 +218,8 @@ START_TEST(test_dn_write_buf)
 	ck_assert(fs->ob_val._file_status._size == towrite);
 	hdfs_object_free(fs);
 
-	s = hdfs_complete(h, tf, client, &e);
+	// XXX this must be updated to cover v2.0+ (last_block/fileid)
+	s = hdfs_complete(h, tf, client, NULL, 0, &e);
 	if (e)
 		fail("exception: %s", hdfs_exception_get_message(e));
 	ck_assert_msg(s, "did not complete");
@@ -297,7 +300,7 @@ START_TEST(test_dn_write_file)
 	begin = _now();
 
 	// write first block (full)
-	bl = hdfs_addBlock(h, tf, client, NULL, &e);
+	bl = hdfs_addBlock(h, tf, client, NULL, NULL, 0, &e);
 	if (e)
 		fail("exception: %s", hdfs_exception_get_message(e));
 
@@ -312,7 +315,8 @@ START_TEST(test_dn_write_file)
 	hdfs_datanode_delete(dn);
 
 	// write second block (partial)
-	bl = hdfs_addBlock(h, tf, client, NULL, &e);
+	// XXX this must be updated to cover v2.0+ (last_block/fileid)
+	bl = hdfs_addBlock(h, tf, client, NULL, NULL, 0, &e);
 	if (e)
 		fail("exception: %s", hdfs_exception_get_message(e));
 
@@ -337,7 +341,8 @@ START_TEST(test_dn_write_file)
 	ck_assert(fs->ob_val._file_status._size == towrite);
 	hdfs_object_free(fs);
 
-	s = hdfs_complete(h, tf, client, &e);
+	// XXX this must be updated to cover v2.0+ (last_block/fileid)
+	s = hdfs_complete(h, tf, client, NULL, 0, &e);
 	if (e)
 		fail("exception: %s", hdfs_exception_get_message(e));
 	ck_assert_msg(s, "did not complete");
@@ -460,7 +465,8 @@ START_TEST(test_short_write)
 	if (e)
 		fail("exception: %s", hdfs_exception_get_message(e));
 
-	bl = hdfs_addBlock(h, tf, client, NULL, &e);
+	// XXX this must be updated to cover v2.0+ (last_block/fileid)
+	bl = hdfs_addBlock(h, tf, client, NULL, NULL, 0, &e);
 	if (e)
 		fail("exception: %s", hdfs_exception_get_message(e));
 
@@ -479,7 +485,8 @@ START_TEST(test_short_write)
 	ck_assert(fs->ob_val._file_status._size == 33128);
 	hdfs_object_free(fs);
 
-	hdfs_complete(h, tf, client, &e);
+	// XXX this must be updated to cover v2.0+ (last_block/fileid)
+	hdfs_complete(h, tf, client, NULL, 0, &e);
 	if (e)
 		fail("exception: %s", hdfs_exception_get_message(e));
 

--- a/tests/t_hl_rpc_basics.c
+++ b/tests/t_hl_rpc_basics.c
@@ -134,7 +134,8 @@ START_TEST(test_append)
 	if (e)
 		ck_abort_msg("exception: %s", hdfs_exception_get_message(e));
 
-	s = hdfs_complete(h, tf, client, &e);
+	// XXX this must be updated to cover v2.0+ (last_block/fileid)
+	s = hdfs_complete(h, tf, client, NULL, 0, &e);
 	if (e)
 		ck_abort_msg("exception: %s", hdfs_exception_get_message(e));
 	ck_assert_msg(s, "complete returned false");
@@ -245,7 +246,8 @@ START_TEST(test_abandonBlock)
 
 	mark_point();
 
-	lb = hdfs_addBlock(h, tf, client, NULL, &e);
+	// XXX this must be updated to cover v2.0+ (last_block/fileid)
+	lb = hdfs_addBlock(h, tf, client, NULL, NULL, 0, &e);
 	if (e)
 		ck_abort_msg("exception: %s", hdfs_exception_get_message(e));
 	ck_assert(!hdfs_object_is_null(lb));
@@ -287,7 +289,8 @@ START_TEST(test_addBlock)
 
 	mark_point();
 
-	lb = hdfs_addBlock(h, tf, client, NULL, &e);
+	// XXX this must be updated to cover v2.0+ (last_block/fileid)
+	lb = hdfs_addBlock(h, tf, client, NULL, NULL, 0, &e);
 	if (e)
 		ck_abort_msg("exception: %s", hdfs_exception_get_message(e));
 	ck_assert(!hdfs_object_is_null(lb));
@@ -316,7 +319,8 @@ START_TEST(test_complete)
 	if (e)
 		ck_abort_msg("exception: %s", hdfs_exception_get_message(e));
 
-	s = hdfs_complete(h, tf, client, &e);
+	// XXX this must be updated to cover v2.0+ (last_block/fileid)
+	s = hdfs_complete(h, tf, client, NULL, 0, &e);
 	if (e)
 		ck_abort_msg("exception: %s", hdfs_exception_get_message(e));
 	ck_assert_msg(s, "complete returned false");

--- a/wrappers/c/hdfs.c
+++ b/wrappers/c/hdfs.c
@@ -337,7 +337,8 @@ hdfsCloseFile(hdfsFS fs, hdfsFile file)
 		}
 
 		while (!succ) {
-			succ = hdfs_complete(client->fs_namenode, f->fi_path, f->fi_client, &ex);
+			// XXX this must be changed if we support v2.0+ here
+			succ = hdfs_complete(client->fs_namenode, f->fi_path, f->fi_client, NULL, 0, &ex);
 			if (ex) {
 				ERR(EIO, "Could not complete '%s', abandoning "
 				    "write: %s", f->fi_path,
@@ -1453,7 +1454,8 @@ _flush(struct hdfs_namenode *fs, struct hdfsFile_internal *f, const void *buf, s
 
 	for (; tries > 0; tries--) {
 		if (!lb) {
-			lb = hdfs_addBlock(fs, f->fi_path, f->fi_client, excl, &ex);
+			// XXX this must be changed if we support v2.0+ here
+			lb = hdfs_addBlock(fs, f->fi_path, f->fi_client, excl, NULL, 0, &ex);
 			if (ex) {
 				ERR(EIO, "addBlock failed: %s", hdfs_exception_get_message(ex));
 				res = -1;

--- a/wrappers/py/chighlevel.pxd
+++ b/wrappers/py/chighlevel.pxd
@@ -21,8 +21,8 @@ cdef extern from "hadoofus/highlevel.h":
     void hdfs_setPermission(hdfs_namenode *n, const_char *path, int16_t perms, hdfs_object **exception_out) nogil
     void hdfs_setOwner(hdfs_namenode *, const_char *path, const_char *owner, const_char *group, hdfs_object **exception_out) nogil
     void hdfs_abandonBlock(hdfs_namenode *, hdfs_object *block, const_char *path, const_char *client, hdfs_object **exception_out) nogil
-    hdfs_object *hdfs_addBlock(hdfs_namenode *n, const_char *path, const_char *client, hdfs_object *excluded, hdfs_object **exception_out) nogil
-    bint hdfs_complete(hdfs_namenode *n, const_char *path, const_char *client, hdfs_object **exception_out) nogil
+    hdfs_object *hdfs_addBlock(hdfs_namenode *n, const_char *path, const_char *client, hdfs_object *excluded, hdfs_object *previous_block, int64_t fileid, hdfs_object **exception_out) nogil
+    bint hdfs_complete(hdfs_namenode *n, const_char *path, const_char *client, hdfs_object *last_block, int64_t fileid, hdfs_object **exception_out) nogil
     bint hdfs_rename(hdfs_namenode *n, const_char *src, const_char *dst, hdfs_object **exception_out) nogil
     bint hdfs_delete(hdfs_namenode *n, const_char *path, bint can_recurse, hdfs_object **exception_out) nogil
     bint hdfs_mkdirs(hdfs_namenode *n, const_char *path, int16_t perms, hdfs_object **exception_out) nogil


### PR DESCRIPTION
This patch changes the highlevel RPC macros to allow different arguments to be used based on the namenode version, with hdfs_complete() and hdfs_addBlock() now taking an H_BLOCK argument and integer fileid argument which are required in v2.2+.

The wrappers and tests have been updated to compile, but they should be reviewed, and a more comprehensive update should be applied to them if they are expected to work with v2.0+ or be considered production quality